### PR TITLE
add the SIDEKIQ_HOST variable for the socket binding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ ADD docker-entrypoint.sh /
 EXPOSE 9292
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["bundle", "exec", "rackup", "config.ru"]
+CMD ["sh", "-c", "bundle exec rackup config.ru --host ${SIDEKIQ_HOST:-127.0.0.1}"]

--- a/README.md
+++ b/README.md
@@ -19,9 +19,12 @@ $ docker run -P -e REDIS_URL=<the redis url> -it sidekiq-web:dev
 ```
 REDIS_SIZE: Concurrency setting (default: 1)
 REDIS_URL: The redis host URL (default: redis://localhost:6379/0)
+SIDEKIQ_HOST: Socket binding for the rack server (default: false)
 SIDEKIQ_CRON: Set to true to enable the Sidekiq Cron view (default: false)
 SIDEKIQ_USERNAME: HTTP Basic Auth username
 SIDEKIQ_PASSWORD: HTTP Basic Auth password
 ```
 
 **NOTE:** To enable HTTP Basic Auth you must set BOTH `SIDEKIQ_USERNAME` and `SIDEKIQ_PASSWORD`.
+
+**OSX NOTE:** When using Docker for Mac you'll need to set the SIDEKIQ_HOST to '0.0.0.0'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -22,6 +22,13 @@ else
     echo "SIDEKIQ_CRON: ${SIDEKIQ_CRON}"
 fi
 
+if [[ "${SIDEKIQ_HOST}" == "" ]]
+then
+    echo "SIDEKIQ_HOST: 127.0.0.1 (default)"
+else
+    echo "SIDEKIQ_HOST: ${SIDEKIQ_HOST}"
+fi
+
 if [[ "${SIDEKIQ_USERNAME}" == "" ]]
 then
     echo "SIDEKIQ_USERNAME: NONE (default)"


### PR DESCRIPTION
When you're on OSX using the current version of Docker for Mac you'll find the default binding of rackup (127.0.0.1) to be too restrictive and won't be able to connect to it.
